### PR TITLE
Update TaskSyncRecoverLoots.java

### DIFF
--- a/ChunkHoppers/src/fr/xxathyx/chunkhoppers/tasks/TaskSyncRecoverLoots.java
+++ b/ChunkHoppers/src/fr/xxathyx/chunkhoppers/tasks/TaskSyncRecoverLoots.java
@@ -29,7 +29,9 @@ public class TaskSyncRecoverLoots extends BukkitRunnable {
 
         for (int i = 0; i < chunk.getTileEntities().length; i++) {        	
             if (chunk.getTileEntities()[i] instanceof Hopper) {
-                hopper = (Hopper) chunk.getTileEntities()[i];
+		if (chunk.getTileEntities()[i].getInventory().getName().equals(configuration.getItemName())) {
+                	hopper = (Hopper) chunk.getTileEntities()[i];
+		}
             }
         }
 		


### PR DESCRIPTION
The way that this class worked before, the For loop would look through every single tile entity in the chunk, and if one of them was a hopper, it would assign it to the "hopper" variable. Only THEN would it check if that hopper was a Chunk Hopper, and if it wasn't, the entity's death/item drop would be completely discarded. As a result, if there was a chunk hopper and a normal hopper in the same chunk, there was a chance that the "hopper" variable would be assigned to the normal hopper but then invalidated, and the chunk hopper would not receive the drops. With this simple change, the check would be made WITHIN the For loop to make sure that the hopper was a Chunk Hopper rather than a normal hopper.