### PR TITLE
BlockGrow does not function with multiple hoppers

### DIFF
--- a/ChunkHoppers/src/fr/xxathyx/chunkhoppers/listeners/BlockGrow.java
+++ b/ChunkHoppers/src/fr/xxathyx/chunkhoppers/listeners/BlockGrow.java
@@ -116,7 +116,9 @@ public class BlockGrow implements Listener {
 	            	                
 	            for (int i = 0; i < chunk.getTileEntities().length; i++) {        	
 	                if (chunk.getTileEntities()[i] instanceof Hopper) {
-	                    hopper = (Hopper) chunk.getTileEntities()[i];
+			    if (chunk.getTileEntities()[i].getInventory().getName().equals(configuration.hoppers_item_name())) {
+	                    	hopper = (Hopper) chunk.getTileEntities()[i];
+			    }
 	                }
 	            }
 	    		


### PR DESCRIPTION
The exact same problem is here in BlockGrow.java that was made in EntityDeath.java before the 1.3 update. When searching though all TileEntities in the chunk, on line 118, the code assumes that the Hopper it found is a Chunk Receptor, even if it isn't. Because of this, if it isn't a Chunk Receptor, the items will simply be destroyed later in the code. It must be checked beforehand, where I've put it in the code.